### PR TITLE
Clean pronunciation of URLs, "LVL1", and "&"

### DIFF
--- a/client/alteration.py
+++ b/client/alteration.py
@@ -24,6 +24,10 @@ def detectLVL1(input):
     LVL1_REGEX = re.compile(r'(?i)\blvl1\b')
     return LVL1_REGEX.sub('level-1', input)
 
+def detectAmpersand(input):
+    AMPERSAND_REGEX = re.compile(r'&')
+    return AMPERSAND_REGEX.sub('and', input)
+
 def clean(input):
     """
         Manually adjust output text before it's translated into
@@ -35,4 +39,4 @@ def clean(input):
         Arguments:
         input -- original speech text to-be modified
     """
-    return detectLVL1(detectYears(simplifyURLs(input)))
+    return detectAmpersand(detectLVL1(detectYears(simplifyURLs(input))))

--- a/client/alteration.py
+++ b/client/alteration.py
@@ -6,6 +6,20 @@ def detectYears(input):
     YEAR_REGEX = re.compile(r'(\b)(\d\d)([1-9]\d)(\b)')
     return YEAR_REGEX.sub('\g<1>\g<2> \g<3>\g<4>', input)
 
+def simplifyURLs(input):
+    # Only affects URLs that start with http(s)://
+    # Removes http(s)://
+    # Removes "www.", but not other subdomains
+    # Removes paths unless they are short enough for a human to remember (i.e. have no slashes)
+    # Removes trailing "/"
+    # Retains ending sentence punctuation (.?!), but doesn't get confused if those chars are inside the URL
+    # http://www.example.com/shorter -> example.com/shorter
+    URL_REGEX_SHORT = re.compile(r'\bhttps?://(www\.|(\w+\.))?([A-Za-z0-9\.\-]+/[\w\.]*[^\W\.])/?(!|\.|\?|)(\s|$)')
+    # http://www.example.com/long/annoying/ -> example.com
+    URL_REGEX = re.compile(r'\bhttps?://(www\.|(\w+\.))?([A-Za-z0-9\.\-]+)(/(\S*([^\.!\?\$\s])|))?(\.|\?|!|)(\s|$|)')
+    return URL_REGEX.sub(lambda m: (m.group(2)or'')+m.group(3)+m.group(7)+m.group(8), \
+                         URL_REGEX_SHORT.sub(lambda m: (m.group(2)or'')+m.group(3)+m.group(4)+m.group(5), input))
+
 def detectLVL1(input):
     LVL1_REGEX = re.compile(r'(?i)\blvl1\b')
     return LVL1_REGEX.sub('level-1', input)
@@ -21,4 +35,4 @@ def clean(input):
         Arguments:
         input -- original speech text to-be modified
     """
-    return detectLVL1(detectYears(input))
+    return detectLVL1(detectYears(simplifyURLs(input)))

--- a/client/alteration.py
+++ b/client/alteration.py
@@ -6,6 +6,9 @@ def detectYears(input):
     YEAR_REGEX = re.compile(r'(\b)(\d\d)([1-9]\d)(\b)')
     return YEAR_REGEX.sub('\g<1>\g<2> \g<3>\g<4>', input)
 
+def detectLVL1(input):
+    LVL1_REGEX = re.compile(r'(?i)\blvl1\b')
+    return LVL1_REGEX.sub('level-1', input)
 
 def clean(input):
     """
@@ -18,4 +21,4 @@ def clean(input):
         Arguments:
         input -- original speech text to-be modified
     """
-    return detectYears(input)
+    return detectLVL1(detectYears(input))


### PR DESCRIPTION
clean() already automatically runs on all text before it is read by the mic.
#### Simple substitutions
- Changes "LVL1" to "level-1"
- Changes "&" to "and"
#### URLs

Simplifies URLs on the assumption that no one wants to hear every detail of a long URL.
- Only affects URLs that start with http(s)://
- Removes http(s)://
- Removes "www.", but not other subdomains
- Removes paths unless they are short enough for a human to remember (i.e. have no inside slashes)
- Removes trailing "/"
- Retains ending sentence punctuation (.?!)
##### URL examples
- "... https://www.example.com"
  - "... example.com"
- "... https://www.example.com/"
  - "... example.com"
- "... https://www.example.com/really/long/link/asdasdasdasdasdas"
  - "... example.com"
- "... https://www.example.com/short"
  - "... example.com/short"
- "... https://www.example.com/short/"
  - "... example.com/short"
- "... http://wiki.example.com/short/? ..."
  - "... wiki.example.com/short? ..."
- etc.
